### PR TITLE
change context for web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - .:/opt/hyrax
+      - ..:/opt/hyrax
       - gems:/opt/bundle
     depends_on:
       - db


### PR DESCRIPTION
Resolves #7 

Change context for web container, so that docker-compose can copy app files from parent directory.