### PR TITLE
Simplify process cleanup in web container build

### DIFF
--- a/docker/web/scripts/docker-entrypoint.sh
+++ b/docker/web/scripts/docker-entrypoint.sh
@@ -18,7 +18,7 @@ if [ "$1" = 'server' ]; then
 
     if [ -f /opt/hyrax/tmp/pids/server.pid ]; then
         echo "Stopping Rails Server and Removing PID File"
-        ps aux |grep -i [r]ails | awk '{print $2}' | xargs kill -9
+        pkill -9 rails
         rm -rf /opt/hyrax/tmp/pids/server.pid
     fi
 


### PR DESCRIPTION
Docker entry-point script clears out rails process during. Encountered error when `ps aux | grep rails` pipes nil to xargs kill command. Prefer `pkill rails` to avoid non-zero exit code in even there is not an active rails process to kill.